### PR TITLE
fix: corrigir gatilho de push para tags em vez de branches no fluxo d…

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -2,12 +2,13 @@ name: ⚡ Performance Testing
 
 on:
   push:
-    branches: [ main ]
+    tags:
+      - 'v*.*.*'
   pull_request:
     branches: [ main ]
-  schedule:
-    # Run performance tests daily at 2 AM UTC
-    - cron: '0 2 * * *'
+  # schedule:
+  #   # Run performance tests daily at 2 AM UTC
+  #   - cron: '0 2 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request updates the performance testing workflow configuration to trigger performance tests only on version tag pushes and pull requests to the `main` branch, instead of on every push to `main` or on a daily schedule.

Workflow trigger changes:

* Modified `.github/workflows/performance.yml` to trigger the workflow on pushes to tags matching the pattern `v*.*.*` instead of all pushes to the `main` branch.
* Commented out the scheduled daily run, so performance tests will no longer run automatically every day at 2 AM UTC.